### PR TITLE
SkillTooltipとの併用＋応用利用を可能に

### DIFF
--- a/IbaracitySearchableBattleForm.user.js
+++ b/IbaracitySearchableBattleForm.user.js
@@ -27,7 +27,7 @@
   SearchableBattleForm.prototype.updateList = function (e) {
     $(`#${this.skillListId()} option`).attr("selected", false);
     $(`#${this.skillListId()}`).val(e.target.dataset.value).trigger('change');
-    $(`#${this.filterdInput()}`).val('').attr('placeholder', e.target.textContent);
+    $(`#${this.filterdInput()}`).val(e.target.textContent).attr('placeholder', e.target.textContent);
     $(`.searchable_ul`).empty();
   }
   SearchableBattleForm.prototype.displayForm = function (id) {
@@ -86,7 +86,12 @@
     });
     $(`#${this.skillListId()}`).after(`<input type="text" class="searchable_input" id="${this.filterdInput()}" placeholder="${placeholder}"></input>` +
       `<ul id="${this.filterdUl()}" class="searchable_ul"></ul>`);
-    $(`#${this.filterdInput()}`).on('input focusin', event => {
+    $(`#${this.filterdInput()}`).val(placeholder).on('focusin', event => {
+      event.target.value = "";
+    }).on('focusout', event => {
+      event.target.value = event.target.placeholder;
+      $(event.target).trigger('change');
+    }).on('input focusin', event => {
       this.updateValue(event)
     });
   }
@@ -126,14 +131,16 @@
       searchableBattleForm.setTab(e);
       $(this).off("click", _handleClick)
     });
-    if(!$('#SkillTooltip').length){
-      $('.searchable_input').hover(function (e) {
-        let offsetTop = e.pageY;
-        let offsetLeft = e.pageX;
-        $('#SkillTooltip').html($(this).prev('select').attr('data-tooltip')).css({'top': offsetTop, 'left': offsetLeft,'z-index': 1 }).show();
-      }, function () {
-        $('#SkillTooltip').empty().hide();
-      });
-    }
+
+    let waitingSkillTooltipSecs = 0;
+    const waitSkillTooltipId = setInterval(() => {
+        if (window.skillTooltip) {
+            window.skillTooltip.bind("skill", ".searchable_input");
+            window.skillTooltip.bind("skill", ".searchable_ul", ".searchable_li");
+        }
+        if (++waitingSkillTooltipSecs >= 30 || window.skillTooltip) {
+            clearInterval(waitSkillTooltipId);
+        }
+    }, 1000)
   }
 })(jQuery);

--- a/IbaracitySearchableBattleForm.user.js
+++ b/IbaracitySearchableBattleForm.user.js
@@ -141,6 +141,6 @@
         if (++waitingSkillTooltipSecs >= 30 || window.skillTooltip) {
             clearInterval(waitSkillTooltipId);
         }
-    }, 1000)
+    }, 1000);
   }
 })(jQuery);


### PR DESCRIPTION
主題のとおりです。

SkillTooltipは対象要素が
・Selectなら選択されているOptionのInnerHtml
・Inputなら要素のValue
・その他の場合はInnerHtml
を参照してスキル名を抽出しツールチップを構成する仕組みです。
対象がonchangeイベントに対応している場合は、onchangeイベント先に表示したツールチップ情報のキャッシュをその要素のdatasetから消去します。

このユーザースクリプトではInput要素が使用されているので、Valueを適宜書き換えるように偏光することでSkillTooltipへの対応を行いました。